### PR TITLE
Fix glitch in lobby schedule display on website

### DIFF
--- a/web.go
+++ b/web.go
@@ -639,9 +639,9 @@ func StationPage(w http.ResponseWriter, r *http.Request) {
 func schedulesToLines(schedules []*dataobjects.LobbySchedule) []string {
 	schedulesByDay := make(map[int]*dataobjects.LobbySchedule)
 	for _, schedule := range schedules {
-		if schedule.Holiday {
+		if schedule.Holiday && schedule.Day == 0 {
 			schedulesByDay[-1] = schedule
-		} else {
+		} else if !schedule.Holiday {
 			schedulesByDay[schedule.Day] = schedule
 		}
 	}


### PR DESCRIPTION
This was broken since the special new year's eve schedules were added to the database